### PR TITLE
Fix infinite loop when dict value is int 0

### DIFF
--- a/src/BencodeTorrent.php
+++ b/src/BencodeTorrent.php
@@ -96,7 +96,7 @@ class BencodeTorrent {
             while ($data[$pos] !== 'e') {
                 $key = $this->decode($data, $pos);
                 $value = $this->decode($data, $pos);
-                if (empty($key) || empty($value)) {
+                if (empty($key) || ($value !== 0 and empty($value))) {
                     break;
                 }
                 $return[$key] = $value;


### PR DESCRIPTION
First, thank you for sharing this code.

This PR fixes an infinite loop that happens if a bencoded string contains a dictionary value that is the integer 0.

When the code encounters i0e as a dict value, the integer handling code sets the $pos variable to a number, lets call it $x. Control then goes back to the dictionary handling section where the test ```if (empty($key) || empty($value))``` passes because PHP's empty() function considers a int 0 to be empty. The loop is then broken and ```$pos++``` happens which increments the position by 1 leading to an off by one error. This can result in some funky issues but it manifested itself in my case as infinite loops during decode.

I hope this is the correct fix. It seemed to work for me.

Please let me know if any of this is incorrect or this is not the proper fix.

