### PR TITLE
Make namespace capitalization consistent

### DIFF
--- a/src/BencodeTorrent.php
+++ b/src/BencodeTorrent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ApolloRip\BencodeTorrent;
+namespace ApolloRIP\BencodeTorrent;
 
 /**
  * BEncode service that allows us to encode PHP objects into BEncode and decode

--- a/tests/BencodeTest.php
+++ b/tests/BencodeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ApolloRip\BencodeTorrent;
+namespace ApolloRIP\BencodeTorrent;
 
 class BencodeTest extends \PHPUnit\Framework\TestCase {
     public function dataProvider() {

--- a/tests/BencodeTorrentTest.php
+++ b/tests/BencodeTorrentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ApolloRip\BencodeTorrent;
+namespace ApolloRIP\BencodeTorrent;
 
 class BencodeTorrentTest extends \PHPUnit\Framework\TestCase {
     public function testLoadTorrent() {


### PR DESCRIPTION
I went with 'ApolloRIP' rather than 'ApolloRip' because it was uppercase in the composer.json.

Without making this change I was getting an error using `use ApolloRIP\BencodeTorrent\BencodeTorrent;` in my code. The error was:

```
Fatal error: Class 'ApolloRip\BencodeTorrent\Bencode' not found in /path/redacted/for/privacy/vendor/apollorip/bencode-torrent/src/BencodeTorrent.php on line 27
```
